### PR TITLE
Add default category handling and that first page is called index.html

### DIFF
--- a/paginator.rb
+++ b/paginator.rb
@@ -45,7 +45,11 @@ module Jekyll
           @site = site
           @base = base
           @dir = dir
-          @name = "page#{page}.html"
+          if (page == 1)
+              @name = "index.html"
+          else
+              @name = "page#{page}.html"
+          end
 
           # Define data which can be used in category.html
           self.process(@name)
@@ -67,7 +71,12 @@ module Jekyll
           # Add prev button for navigation
           if page > 1
               prevNumber = page - 1
-              self.data['prevUrl'] = File.join('', dir, "page#{prevNumber}.html")
+              if (page == 2)
+                  page_file = "index.html"
+              else 
+                  page_file = "page#{prevNumber}.html" 
+              end
+              self.data['prevUrl'] = File.join('', dir, page_file)
           end
       end
   end
@@ -87,7 +96,9 @@ module Jekyll
         list = list.sort! { |a,b| b.date <=> a.date }
 
         # Put each page file in a subfolder of dir
-        dir = File.join(dir, category)
+        if not details[category]['default'] 
+          dir = File.join(dir, category)
+        end
 
         # Calculate number of pages
         pages = (detail['pagination'] / list.length).ceil


### PR DESCRIPTION
Hi, 
Please excuse if by design you did not include this. But I had to slightly modify your awesome plugin to meet my requirements. You could see it now implemented on my humble blog http://emmanuel-galindo.github.io/. My idea was that I could mainly generate English articles, but time to time, I find some topic could be useful in my native language. 

Therefore, I was requiring that from a list of categories, one could be default, and all the built pages land on the main directory. 
I wanted also that the first page (page1.html) was actually called index.html.

Well let me know if any, or just ignore this.. it is all good, I am really appreciated of finding your work as it already helped me a lot. 

The only change not included in the pull, is at _config.yml, the default tag at a category level.

```
categories:
  pagination: 5
  layout: category.html
  directory: .
  details:
    es:
      weight: 25
    en:
      default: true
      weight: 50
```

Thanks,
Emmanuel.
